### PR TITLE
Fix hook log showing the wrong icon

### DIFF
--- a/master.css
+++ b/master.css
@@ -159,6 +159,11 @@ a[href*="/redeploy"].task-icon-link {
   background-size: contain !important;
 }
 
+a[href*="/GitHubPollLog"].task-icon-link {
+    background: url(img/git.png) no-repeat!important;
+    background-size: contain!important;
+}
+
 div.task a[href="#"]:first-child { 
   background: url(img/x.png) no-repeat !important; 
   background-size: contain !important;


### PR DESCRIPTION
As you can see in the image, it shows the 'back' icon. I fixed it for you c:

![icon](http://puu.sh/akEYb/a5946dc39b.png)
