### PR TITLE
Consistent formatting for login/signup elements

### DIFF
--- a/master.css
+++ b/master.css
@@ -343,9 +343,19 @@ a[href="#"] img {
     color: #666 !important;
 }
 
-.model-link:hover {
+.model-link:not(.login span a):hover {
     color: #555 !important;
     background: #f0f0f0 !important;
+}
+
+.login a[href^="/login"],a[href^="/signup"] {
+    color: #fff !important;
+    background: none;
+}
+
+.login a[href^="/login"]:hover,a[href^="/signup"]:hover {
+    color: #000;
+    background: none;
 }
 
 .login span a {
@@ -355,6 +365,7 @@ a[href="#"] img {
 
 .login span a:hover {
     color: #000;
+    background: none;
 }
 
 a[href*="lastSuccessfulBuild/artifact/target/"]:hover {


### PR DESCRIPTION
Before:
![before](http://puu.sh/azSeN/d1be3f124a.png)

After:
![after](http://puu.sh/azSe4/4ffb356082.png)

Also excludes the logged in element from the background hover effect. So **no more** of this:

![hover](http://puu.sh/azSYq/25fd6c33c3.png)
