### PR TITLE
Use a custom image for the artifacts section of job pages

### DIFF
--- a/master.css
+++ b/master.css
@@ -168,6 +168,17 @@ a[href*="/GitHubPollLog"].task-icon-link {
     background-size: contain!important;
 }
 
+img[src$="package.png"] {
+    display: block;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    background: url(img/views.png) no-repeat !important;
+    background-size: contain !important;
+    height: 48px;
+    width: 48px;
+    padding-left: 48px;
+}
+
 div.task a[href="#"]:first-child {
     background: url(img/x.png) no-repeat !important;
     background-size: contain !important;


### PR DESCRIPTION
Fixes the `last successful artifacts` image.

Before:

![before](http://puu.sh/aBoCD/fc4d882e58.png)

After:

![after](http://puu.sh/aBoDT/c838e9f134.png)
